### PR TITLE
Fixes to apnews.com hub config

### DIFF
--- a/lib/html2rss/configs/apnews.com/hub.yml
+++ b/lib/html2rss/configs/apnews.com/hub.yml
@@ -14,3 +14,9 @@ selectors:
     extractor: href
   description:
     selector: p
+  updated:
+    selector: ".Timestamp"
+    extractor: attribute
+    attribute: data-source
+    post_process:
+      name: "parse_time"

--- a/lib/html2rss/configs/apnews.com/hub.yml
+++ b/lib/html2rss/configs/apnews.com/hub.yml
@@ -8,7 +8,7 @@ selectors:
   items:
     selector: ".FeedCard"
   title:
-    selector: h3
+    selector: h2
   link:
     selector: a:first
     extractor: href


### PR DESCRIPTION
Current APNews attempts to pull h3 tags for titles, which has been changed to h2 tags. I have also added the tag for timestamps.