### PR TITLE
feat: drop support for ruby <3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
 
       - name: setup remote origin

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
 
       - name: Run linters
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["3.1"]
 
     runs-on: ubuntu-latest
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.7
   Exclude:
     - vendor/**/*
 

--- a/html2rss-configs.gemspec
+++ b/html2rss-configs.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Configs which contain information how to generate RSS items from websites.'
   spec.homepage = 'https://github.com/html2rss/html2rss-configs'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.1'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/lib/html2rss/configs/generator/channel_question.rb
+++ b/lib/html2rss/configs/generator/channel_question.rb
@@ -40,7 +40,7 @@ module Html2rss
         end
 
         def process(url)
-          { url: url, language: doc.css('html').first['lang'], ttl: 360, time_zone: 'UTC' }
+          { url:, language: doc.css('html').first['lang'], ttl: 360, time_zone: 'UTC' }
             .keep_if { |_key, value| value.to_s != '' }
         end
 

--- a/lib/html2rss/configs/generator/question.rb
+++ b/lib/html2rss/configs/generator/question.rb
@@ -20,7 +20,7 @@ module Html2rss
           before_ask
           validated_input = prompt.ask(question, **prompt_options) do |answer|
             answer.validate lambda { |input|
-              args = { input: input, state: state, prompt: prompt, options: @options }
+              args = { input:, state:, prompt:, options: @options }
               self.class.validate(**args)
             }
           end

--- a/lib/html2rss/configs/print_helper.rb
+++ b/lib/html2rss/configs/print_helper.rb
@@ -38,7 +38,7 @@ module Html2rss
 
         code = HtmlBeautifier.beautify(code) if Object.const_defined?('HtmlBeautifier') && lang == :html
 
-        markdown ["```#{lang}", code, '```'].join("\n"), output: output
+        markdown ["```#{lang}", code, '```'].join("\n"), output:
       end
 
       ##

--- a/spec/html2rss/configs/generator_spec.rb
+++ b/spec/html2rss/configs/generator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Html2rss::Configs::Generator do
   it { expect(described_class).to be_a(Module) }
 
   describe '.start' do
-    let(:prompt) { TTY::Prompt.new(input: input) }
+    let(:prompt) { TTY::Prompt.new(input:) }
     let(:state) { Html2rss::Configs::Generator::State.new(feed: {}) }
     let(:options) { { path: 'spec.path', question: 'Path?' } }
 
@@ -88,7 +88,7 @@ RSpec.describe Html2rss::Configs::Generator do
 
     let(:faraday) do
       instance_double(Faraday::Connection,
-                      get: instance_double(Faraday::Response, success?: true, body: body))
+                      get: instance_double(Faraday::Response, success?: true, body:))
     end
 
     before do

--- a/spec/html2rss/configs/print_helper_spec.rb
+++ b/spec/html2rss/configs/print_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Html2rss::Configs::PrintHelper do
     let(:output) { StringIO.new }
 
     it do
-      expect { described_class.code(:html, messy_html, output: output) }
+      expect { described_class.code(:html, messy_html, output:) }
         .to change(output, :string)
         .from('')
         .to(/Foo goes into a bar and... buz/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'bundler/setup'
 require 'html2rss'
 require 'html2rss/configs'
 
-Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This is a BREAKING CHANGE.

Make sure to use ruby 3.1 (latest). If you're using html2rss-web, there is no need to change anything.

Also related: https://github.com/html2rss/html2rss/pull/156